### PR TITLE
Fix shell syntax error when emacs-snapshot not found.

### DIFF
--- a/run-travis-ci.sh
+++ b/run-travis-ci.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-if [ `uname` = "Darwin" ]; then
+if [ "$(uname)" = "Darwin" ]; then
   # for local testing only
   EMACS="/Applications/Emacs.app/Contents/MacOS/Emacs"
-elif [ `which emacs-snapshot` != "" ]; then
+elif [ "$(which emacs-snapshot)" != "" ]; then
   EMACS="$(which emacs-snapshot)"
 else
   EMACS="$(which emacs)"


### PR DESCRIPTION
On my Linux laptop I don't have such thing as `emacs-snapshot`. So shell command `which emacs-snapshot` returns nothing for me. Because of that in `run-travis-ci.sh` expression `[ `which emacs-snapshot` != "" ]` becomes `[ != "" ]` which is syntactically incorrect. So every time I run `run-travis-ci.sh` I see the following error:

```
./run-travis-ci.sh: line 6: [: !=: unary operator expected
...
```

Using `$()` along with double quotes instead of backticks fixes the problem.

Thanks.
